### PR TITLE
chore: add pre-commit hooks for cargo checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,8 @@
 repos:
-  - repo: local
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: eeee35a89e69d5772bdee97db1a6a898467b686e  # frozen: v1.0
     hooks:
       - id: cargo-check
-        name: cargo c
-        entry: cargo c --all-targets --all --locked
-        language: system
-        pass_filenames: false
-      - id: cargo-fmt
-        name: cargo fmt --check
-        entry: cargo fmt --all -- --check
-        language: system
-        pass_filenames: false
+        args: [--all-targets, --all, --locked]
+      - id: fmt
+        args: [--all, --, --check]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-check
+        name: cargo c
+        entry: cargo c --all-targets --all --locked
+        language: system
+        pass_filenames: false
+      - id: cargo-fmt
+        name: cargo fmt --check
+        entry: cargo fmt --all -- --check
+        language: system
+        pass_filenames: false


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` for Rust checks
- configure pre-commit hooks from `doublify/pre-commit-rust`
- pin hook repo to commit `eeee35a89e69d5772bdee97db1a6a898467b686e` (`v1.0`)

## Checks
- `cargo check` via `cargo-check` hook with `--all-targets --all --locked`
- `cargo fmt --all -- --check` via `fmt` hook

Closes #7
